### PR TITLE
Fixed column/row miss-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ about the patients including their age, treatment, and diagnosis. You would have
 information. It would have four columns (patient id, age, treatment, diagnosis) and 21 rows (a row with variable names, then one row
 for every patient). You would also have one spreadsheet for the summarized genomic data. Usually this type of data
 is summarized at the level of the number of counts per exon. Suppose you have 100,000 exons, then you would have a
-table/spreadsheet that had 21 rows (a row for gene names, and one row for each patient) and 100,001 columns (one row for patient
-ids and one row for each data type). 
+table/spreadsheet that had 21 rows (a row for gene names, and one row for each patient) and 100,001 columns (one column for patient ids and one column for each data type). 
 
 If you are sharing your data with the collaborator in Excel, the tidy data should be in one Excel file per table. They
 should not have multiple worksheets, no macros should be applied to the data, and no columns/cells should be highlighted. 


### PR DESCRIPTION
The parenthetical comment describing why the table would have 100,001 columns accidentally used the word row instead of column.
